### PR TITLE
Commenting updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains the guidelines for writing CSS and SCSS at Shopify.
 * [Commenting](commenting)
   * [Inline comments](commenting#inline-comments)
   * [Block comments](commenting#block-comments)
-  * [Function comments](commenting#function-comments)
+  * [File comments](commenting#file-comments)
+  * [Function and mixin comments](commenting#function-and-mixin-comments)
 
 Continue on to [the Introduction →](introduction#introduction)

--- a/commenting/readme.md
+++ b/commenting/readme.md
@@ -3,7 +3,8 @@
 ## Table of contents
 * [Inline comments](#inline-comments)
 * [Block comments](#block-comments)
-* [Function comments](#function-comments)
+* [File comments](#file-comments)
+* [Function and mixin comments](#function-and-mixin-comments)
 
 ## Inline comments
 Inline comments should be displayed on the line above the related line of code.
@@ -29,7 +30,7 @@ Inline comments should be displayed on the line above the related line of code.
 ```
 
 ## Block comments
-Block comments should be used to create meaningful divisions in your file. Each block comment should be preceded by a line with a `//`.
+Block comments should be used to create meaningful divisions in your file. Each block comment should be preceded by a line with a `///` and followed with an empty line.
 
 ```scss
 // Bad!
@@ -44,27 +45,70 @@ Block comments should be used to create meaningful divisions in your file. Each 
   color: red;
 }
 
+// Bad!
+//
+// You should use three slashes instead of two for block comments
+
+//
+// This is a bad block comment
+
+.red-bull {
+  content: 'bull';
+  color: red;
+}
+
 
 // Good!
 
-//
-// This is a good block comment
+///
+/// This is a good block comment
+
 .red-bull {
   content: 'bull';
   color: red;
 }
 ```
 
-## Function comments
-Function comments should list the paramers and return values.
+## File comments
+File comments (or poster comments as they are referred to in SassDoc) should be used to label an overall file. Each file comment should be preceded and followed by a line with `////`. It is also a good idea to add a `@group` to help structure our SassDocs
+
+```scss
+// Bad!
+//
+// You shouldn't mix characters for signifying block comments
+
+/*
+ This is a bad file comment
+*/
+.red-bull {
+  content: 'bull';
+  color: red;
+}
+
+
+// Good!
+
+////
+/// This is a good file comment
+/// @group component/red-bull
+////
+.red-bull {
+  content: 'bull';
+  color: red;
+}
+```
+
+## Function and mixin comments
+Function and mixins should have comments that list the paramers and return values.
 
 ```scss
 // Bad!
 //
 // You should list all parameters and the return value
 
-//
-// Returns the value in pixels for a given rem value.
+///
+/// Returns the value in pixels for a given rem value.
+
 @function px($value) {
   @if unit($value) != 'rem' {
     @error 'Value must be in rem.';
@@ -74,10 +118,10 @@ Function comments should list the paramers and return values.
 
 // Good!
 
-//
-// Returns the value in pixels for a given rem value.
-// @param {Number} $value - The rem value to be converted.
-// @return {Number} The converted value in pixels.
+///
+/// Returns the value in pixels for a given rem value.
+/// @param {Number} $value - The rem value to be converted.
+/// @return {Number} The converted value in pixels.
 
 @function px($value) {
   @if unit($value) != 'rem' {

--- a/introduction/readme.md
+++ b/introduction/readme.md
@@ -12,6 +12,7 @@ This document outlines the concepts required to write Sass in our design system.
 * [Sass](http://sass-lang.com/) is our preprocessor of choice
 * [PostCSS](https://github.com/postcss/postcss) for its [Autoprefixer](https://github.com/postcss/autoprefixer) plugin
 * [SCSS-Lint](https://github.com/causes/scss-lint) is our preferred linter for `SCSS`. See our custom [linting rules](https://github.com/Shopify/css/blob/master/.scss-lint.yml) and plugins [linting rules](https://github.com/Shopify/css/blob/master/scss-lint-plugins)
+* [SassDoc](https://github.com/SassDoc/) is our preferred form of documentation
 
 ## Philosophy and structure
 

--- a/introduction/readme.md
+++ b/introduction/readme.md
@@ -12,7 +12,7 @@ This document outlines the concepts required to write Sass in our design system.
 * [Sass](http://sass-lang.com/) is our preprocessor of choice
 * [PostCSS](https://github.com/postcss/postcss) for its [Autoprefixer](https://github.com/postcss/autoprefixer) plugin
 * [SCSS-Lint](https://github.com/causes/scss-lint) is our preferred linter for `SCSS`. See our custom [linting rules](https://github.com/Shopify/css/blob/master/.scss-lint.yml) and plugins [linting rules](https://github.com/Shopify/css/blob/master/scss-lint-plugins)
-* [SassDoc](https://github.com/SassDoc/) is our preferred form of documentation
+* [SassDoc](https://github.com/SassDoc/sassdoc) is our preferred form of documentation
 
 ## Philosophy and structure
 


### PR DESCRIPTION
This updates our commenting standard to be compliant with [SassDoc](https://github.com/SassDoc/sassdoc).

This means using `///` instead of `//` where we want SassDoc to pick it up. It also adds file level comment blocks.

@ry5n @beefchimi for review

cc @Shopify/css 